### PR TITLE
Simplified installation: colours.txt path does not have to be modified

### DIFF
--- a/DensityMap.pl
+++ b/DensityMap.pl
@@ -8,6 +8,8 @@ use Getopt::Long;
 #use Data::Dumper;
 use GD::SVG;
 use POSIX;
+use Cwd 'abs_path';
+use File::Basename;
 
 #> Setting Parameters
 
@@ -289,7 +291,7 @@ my $image = GD::SVG::Image->new($picWidth, $picHeight);
 
 # 3 Loading colors from colours.txt
 print "Load colours ...\n" if $config{'verbose'};
-open(COLOR, "</usr/local/share/DensityMap/colours.txt") or die "Can not open colours.txt";
+open(COLOR, "<".dirname(abs_path($0))."/colours.txt") or die "Can not open colours.txt";
 while (<COLOR>) {
     next if /^#/;
     /([\d\w]+);(\d+);(\d+);(\d+)/;

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,6 @@
 
 mkdir /usr/local/share/DensityMap
 cp -r ./* /usr/local/share/DensityMap
-perl -i -pe 's/.\/colours.txt/\/usr\/local\/share\/DensityMap\/colours.txt/' /usr/local/share/DensityMap/DensityMap.pl
 cd /usr/local/bin
 ln -s /usr/local/share/DensityMap/DensityMap.pl
 


### PR DESCRIPTION
Hey, 

I made a small change to the location detection of the colours.txt file. Now the path doesn't have to be changed anymore. This simplifies an installation to a different folder than /usr/local/. 

I'd appreciate it if you will merge this to your repository.

Greetings,
Lukas
