### PR TITLE
Accept ##sequence-region minimum greater than 1

### DIFF
--- a/DensityMap.pl
+++ b/DensityMap.pl
@@ -187,7 +187,7 @@ my $switchInitFasta = 0;
 
 while (<GFF>) {
     chomp;
-    if (/##sequence-region\s+(\S+)\s+1\s+(\d+)/) {
+    if (/##sequence-region\s+(\S+)\s+\d+\s+(\d+)/) {
         $numOfGff++;
         $initHeadSeq = $1;
         $listChr{$initHeadSeq}{length} = $2;
@@ -364,7 +364,7 @@ open(CSV, ">$csv") or die "Can not open $csv ! ";
 print CSV "sequence\tfeature\tstart\tend\tdensity\n";
 
 while (<GFF>) {
-    if (/##sequence-region\s+(\S+)\s+1\s+(\d+)/) {
+    if (/##sequence-region\s+(\S+)\s+\d+\s+(\d+)/) {
         if ($switchFirstSetLoaded){
             processData();
             $countGff++;


### PR DESCRIPTION
DensityMap does not accept values greater than 1 for the minimum of ##sequence-region. This commit allows the tool to accept values greater than 1.

For example.
Line 2 of dmel.gff3 the minimum for the region is 1.
##sequence-region 2L 1 23513712
In my gff3 files the minimum value varies by ##sequence-region, and DensityMap cannot interpret these lines.